### PR TITLE
Bump sqlparser to 0.20.0 and fix the test compilation issue

### DIFF
--- a/convergence-arrow/Cargo.toml
+++ b/convergence-arrow/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/returnString/convergence"
 
 [dependencies]
 tokio = { version = "1" }
-sqlparser = "0.18"
+sqlparser = "0.20"
 async-trait = "0.1"
 datafusion = "11"
 convergence = { path = "../convergence", version = "0.5.0" }

--- a/convergence/Cargo.toml
+++ b/convergence/Cargo.toml
@@ -13,7 +13,7 @@ tokio-util = { version = "0.7", features = [ "codec" ] }
 thiserror = "1"
 bytes = "1"
 futures = "0.3"
-sqlparser = "0.18"
+sqlparser = "0.20"
 async-trait = "0.1"
 chrono = "0.4"
 

--- a/convergence/tests/test_connection.rs
+++ b/convergence/tests/test_connection.rs
@@ -26,7 +26,7 @@ impl Engine for ReturnSingleScalarEngine {
 
 	async fn prepare(&mut self, statement: &Statement) -> Result<Vec<FieldDescription>, ErrorResponse> {
 		if let Statement::Query(query) = &statement {
-			if let SetExpr::Select(select) = &query.body {
+			if let SetExpr::Select(select) = &*query.body {
 				if select.projection.len() == 1 {
 					if let SelectItem::UnnamedExpr(Expr::Identifier(column_name)) = &select.projection[0] {
 						match column_name.value.as_str() {


### PR DESCRIPTION
Bump the sqlparser version so that it is aligned with datafusion 11. 

Also fix the test compilation issue, triggered with sqlparser > 0.18.